### PR TITLE
adding message to create new repository to clone

### DIFF
--- a/docs/deploy/template.rst
+++ b/docs/deploy/template.rst
@@ -26,12 +26,12 @@ token for both the command line and Pythonic approaches below.
 Command Line Usage
 ==================
 
-To template a repository and then clone your template, you can add the --remote
+To template a repository and then clone your template, you can add the --create-remote
 flag:
 
 .. code-block:: console
 
-     $ snakedeploy https://github.com/snakemake-workflows/dna-seq-varlociraptor /tmp/dest --remote
+     $ snakedeploy https://github.com/snakemake-workflows/dna-seq-varlociraptor /tmp/dest --create-remote
 
 
 If you don't provide a ``--name``, then the repository will be templated with your
@@ -49,7 +49,7 @@ a default name. Here is how I'd ask for a custom name "vsoch/dna-seq":
 
 .. code-block:: console
 
-    $ snakedeploy https://github.com/snakemake-workflows/dna-seq-varlociraptor /tmp/dest --remote --name vsoch/dna-seq
+    $ snakedeploy https://github.com/snakemake-workflows/dna-seq-varlociraptor /tmp/dest --create-remote --name vsoch/dna-seq
 
 
 Python Usage

--- a/snakedeploy/client.py
+++ b/snakedeploy/client.py
@@ -34,7 +34,7 @@ def get_parser():
 
     deploy_group = parser.add_argument_group("DEPLOY")
     deploy_group.add_argument(
-        "--remote",
+        "--create-remote",
         dest="template",
         help="Template the repository first to create a remote to clone. GITHUB_TOKEN is required.",
         default=False,

--- a/snakedeploy/providers/github.py
+++ b/snakedeploy/providers/github.py
@@ -110,6 +110,10 @@ class GitHubProvider:
             if not keep_git and os.path.exists(git):
                 logger.debug(f"Cleaning up {git}")
                 shutil.rmtree(git)
+                logger.info(
+                    "To create the remote repository on Github, open\n\n"
+                    "https://github.com/new\n\n"
+                )
 
             return dest
         logger.exit(f"Error cloning repository: {return_code}")


### PR DESCRIPTION
If we remove the git history, we want to tell the user how to go online to GitHub to create a new repository.

Signed-off-by: vsoch <vsochat@stanford.edu>