### PR TITLE
removing pandas dependency, replacing with reading csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.2.x](https://github.com/snakemake/snakedeploy/tree/master) (0.0.x)
+ - adding collect-files command (0.0.13)
  - updating --remote to --create-remote and adding message to clone (0.0.12)
  - adding option to template with GitHub (if GitHub token is present) (0.0.11)
  - beta release with working clone (0.0.1)

--- a/docs/deploy/deploy.rst
+++ b/docs/deploy/deploy.rst
@@ -17,7 +17,7 @@ You can do that as follows:
 
 .. code-block:: console
 
-    $ snakedeploy https://github.com/snakemake-workflows/dna-seq-varlociraptor /tmp/dest
+    $ snakedeploy deploy-workflow https://github.com/snakemake-workflows/dna-seq-varlociraptor /tmp/dest
 
 
 You'll then see the repository clone

--- a/docs/deploy/template.rst
+++ b/docs/deploy/template.rst
@@ -31,7 +31,7 @@ flag:
 
 .. code-block:: console
 
-     $ snakedeploy https://github.com/snakemake-workflows/dna-seq-varlociraptor /tmp/dest --create-remote
+     $ snakedeploy deploy-workflow https://github.com/snakemake-workflows/dna-seq-varlociraptor /tmp/dest --create-remote
 
 
 If you don't provide a ``--name``, then the repository will be templated with your
@@ -49,7 +49,7 @@ a default name. Here is how I'd ask for a custom name "vsoch/dna-seq":
 
 .. code-block:: console
 
-    $ snakedeploy https://github.com/snakemake-workflows/dna-seq-varlociraptor /tmp/dest --create-remote --name vsoch/dna-seq
+    $ snakedeploy deploy-workflow https://github.com/snakemake-workflows/dna-seq-varlociraptor /tmp/dest --create-remote --name vsoch/dna-seq
 
 
 Python Usage

--- a/docs/getting_started/tools.rst
+++ b/docs/getting_started/tools.rst
@@ -1,0 +1,31 @@
+.. _getting_started-tools:
+
+=====
+Tools
+=====
+
+Snakedeploy provides several command line tools for preparing or otherwise
+interacting with your data or workflow.
+
+
+Collecting Files
+================
+
+Let's say that we have a tab separated sheet of inputs called ``unit-patterns.tsv``:
+
+.. code:: console
+
+    S743_Nr(?P<nr>[0-9]+)	S743_1/01_fastq/S743Nr{nr}.*.fastq.gz
+    S839_Nr(?P<nr>[0-9]+)	S839_*/01_fastq/S839Nr{nr}.*.fastq.gz
+    S888_Nr(?P<nr>[0-9]+)	S888/S888_1/01_fastq/S888Nr{nr}.*.fastq.gz
+
+
+And then a file of samples, ``samples.tsv`` where the first column contains the sample ids. If we want to collect files on the system based on a glob
+pattern of interest and print them to STDOUT (along with the sample id) we can do:
+
+.. code:: console
+
+    cut -f1 samples.tsv | tail -n+2 | snakedeploy collect-files --config unit-patterns.tsv
+
+
+More specifically, the config sheet above lets us select, for each sample, a glob pattern, which is then used to obtain the files on disk that correspond to this sample, which are then printed tab separated to STDOUT, along with the sample id that we put in.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,9 +38,10 @@ Deployment means that you have the following options:
  1. Clone the repository template as is, removing the .git history
  2. "Template" the repository (meaning forking without keeping connected to the parent) and clone the fork. In this case, we keep the .git history as you will likely want to push back to the repository.
 
-For the second option, you will need a `GITHUB_TOKEN` (a personal access token) exported in
+For the second option, you will need a ``GITHUB_TOKEN`` (a personal access token) exported in
 the environment. You are also given the option to specify the `--name` of your templated repository.
-Both of these options are discussed in :ref:`deploy`.
+Both of these options are discussed in :ref:`deploy`. For additional tools provided by snakedeploy,
+see :ref:`getting_started-tools`.
 
 The library is fairly simple now, but will be used as a base for an interactive
 tool to run snakemake workflows. Stay tuned!

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,8 @@
 #!/usr/bin/env python
 
-"""
-
-Copyright (C) 2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 
 from setuptools import setup, find_packages

--- a/snakedeploy/__init__.py
+++ b/snakedeploy/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2020, Vanessa SOchat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from .version import __version__

--- a/snakedeploy/client.py
+++ b/snakedeploy/client.py
@@ -88,7 +88,9 @@ def get_parser():
     )
 
     deploy_workflow_parser.add_argument(
-        "dest", nargs="?", help="Path to clone the repository, should not exist.",
+        "dest",
+        nargs="?",
+        help="Path to clone the repository, should not exist.",
     )
 
     deploy_workflow_parser.add_argument(

--- a/snakedeploy/client.py
+++ b/snakedeploy/client.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2020, Vanessa SOchat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from snakedeploy.logger import setup_logger

--- a/snakedeploy/collect_files.py
+++ b/snakedeploy/collect_files.py
@@ -4,14 +4,19 @@ import re
 import logging
 from collections import namedtuple
 
-import pandas as pd
-
 from snakedeploy.exceptions import UserError
+from snakedeploy.utils import read_csv
 
 
 def collect_files(config_sheet_path: str):
-    config_sheet = pd.read_csv(config_sheet_path, sep="\t")
-    config_sheet["input_re"] = config_sheet["input_pattern"].apply(re.compile)
+    """Given a configuration sheet path with input patterns, print matches
+    of samples to STDOUT
+    """
+    config_sheet = read_csv(config_sheet_path, sep="\t")
+
+    # Input patterns are in the first column, add regex to last column
+    for row in config_sheet:
+        row.append(re.compile(row[0]))
 
     for item in sys.stdin:
         item = item[:-1]  # remove newline
@@ -26,30 +31,26 @@ def collect_files(config_sheet_path: str):
             raise UserError(f"No input pattern in config sheet matches {item}.")
         elif len(matches) > 1:
             raise UserError(f"Item {item} matches multiple input patterns.")
-        else:
-            match = matches[0]
-            pattern = match.rule.glob_pattern.format(
-                **{
-                    key: autoconvert(value)
-                    for key, value in match.match.groupdict().items()
-                }
-            )
-            files = sorted(glob(pattern))
-            if files:
-                print(item, *files, sep="\t")
-            else:
-                raise UserError(
-                    f"No files were found for {item} with pattern {pattern}."
-                )
+
+        match = matches[0]
+        pattern = match.rule.glob_pattern.format(
+            **{
+                key: autoconvert(value)
+                for key, value in match.match.groupdict().items()
+            }
+        )
+        files = sorted(glob(pattern))
+        if not files:
+            raise UserError(f"No files were found for {item} with pattern {pattern}.")
+
+        print(item, *files, sep="\t")
 
 
 Match = namedtuple("Match", "rule match")
 
 
-def get_matches(item, config_sheet: pd.DataFrame):
-    return (
-        Match(rule, rule.input_re.match(item)) for rule in config_sheet.itertuples()
-    )
+def get_matches(item, config_sheet: list):
+    return (Match(rule, rule[-1].match(item)) for rule in config_sheet)
 
 
 def autoconvert(value):

--- a/snakedeploy/collect_files.py
+++ b/snakedeploy/collect_files.py
@@ -1,7 +1,6 @@
 import sys
 from glob import glob
 import re
-import logging
 from collections import namedtuple
 
 from snakedeploy.exceptions import UserError

--- a/snakedeploy/exceptions.py
+++ b/snakedeploy/exceptions.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2020, Vanessa SOchat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 

--- a/snakedeploy/logger.py
+++ b/snakedeploy/logger.py
@@ -1,15 +1,6 @@
-"""
-
-Copyright (C) 2020 Vanessa Sochat.
-
-This Source Code Form is subject to the terms of the
-Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-This logger was originally derived from snakemake, and simplified for the client
-here. https://github.com/snakemake/snakemake/blob/master/snakemake/logging.py
-
-"""
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
+__license__ = "MPL 2.0"
 
 import logging as _logging
 import platform

--- a/snakedeploy/providers/__init__.py
+++ b/snakedeploy/providers/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2020, Vanessa SOchat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from .github import GitHubProvider

--- a/snakedeploy/providers/base.py
+++ b/snakedeploy/providers/base.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2020, Vanessa SOchat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import abc

--- a/snakedeploy/providers/github.py
+++ b/snakedeploy/providers/github.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2020, Vanessa SOchat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import re

--- a/snakedeploy/utils.py
+++ b/snakedeploy/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2020, Vanessa SOchat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 import csv

--- a/snakedeploy/utils.py
+++ b/snakedeploy/utils.py
@@ -4,8 +4,6 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-import csv
-import os
 import subprocess
 import sys
 
@@ -20,19 +18,6 @@ def decodeUtf8String(inputStr):
         if isinstance(inputStr, str) or not isinstance(inputStr, bytes)
         else inputStr.decode("utf8")
     )
-
-
-def read_csv(filename, sep="\t"):
-    """Given a filename, read and parse into a list of lists"""
-    if not os.path.exists(filename):
-        raise FileNotFoundError("%s does not exist." % filename)
-
-    rows = []
-    with open(filename, "r") as fd:
-        reader = csv.reader(fd, delimiter=sep)
-        for row in reader:
-            rows.append(row)
-    return rows
 
 
 def run_command(

--- a/snakedeploy/utils.py
+++ b/snakedeploy/utils.py
@@ -4,6 +4,8 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2020, Vanessa SOchat"
 __license__ = "MPL 2.0"
 
+import csv
+import os
 import subprocess
 import sys
 
@@ -20,8 +22,24 @@ def decodeUtf8String(inputStr):
     )
 
 
+def read_csv(filename, sep="\t"):
+    """Given a filename, read and parse into a list of lists"""
+    if not os.path.exists(filename):
+        raise FileNotFoundError("%s does not exist." % filename)
+
+    rows = []
+    with open(filename, "r") as fd:
+        reader = csv.reader(fd, delimiter=sep)
+        for row in reader:
+            rows.append(row)
+    return rows
+
+
 def run_command(
-    cmd, capture=True, environ=None, quiet=False,
+    cmd,
+    capture=True,
+    environ=None,
+    quiet=False,
 ):
 
     """run_command uses subprocess to send a command to the terminal. If

--- a/snakedeploy/version.py
+++ b/snakedeploy/version.py
@@ -1,5 +1,5 @@
 __author__ = "Vanessa Sochat"
-__copyright__ = "Copyright 2020, Vanessa SOchat"
+__copyright__ = "Copyright 2020-2021, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 __version__ = "0.0.13"

--- a/snakedeploy/version.py
+++ b/snakedeploy/version.py
@@ -14,8 +14,11 @@ LICENSE = "LICENSE"
 ################################################################################
 # Global requirements
 
+INSTALL_REQUIRES = (
+    ("requests", {"min_version": None}),
+    ("pandas", {"min_version": None}),
+)
 
-INSTALL_REQUIRES = (("requests", {"min_version": None}),)
 TESTS_REQUIRES = (("pytest", {"min_version": "4.6.2"}),)
 
 

--- a/snakedeploy/version.py
+++ b/snakedeploy/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2020, Vanessa SOchat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "snakedeploy"
@@ -15,10 +15,7 @@ LICENSE = "LICENSE"
 # Global requirements
 
 
-INSTALL_REQUIRES = (
-    ("requests", {"min_version": None}),
-    ("pandas", {"min_version": None}),
-)
+INSTALL_REQUIRES = (("requests", {"min_version": None}),)
 TESTS_REQUIRES = (("pytest", {"min_version": "4.6.2"}),)
 
 

--- a/tests/test_client.sh
+++ b/tests/test_client.sh
@@ -30,10 +30,10 @@ runTest 0 $output snakedeploy --help
 
 echo
 echo "#### Testing snakedeploy deployment"
-runTest 0 $output snakedeploy "${repo}" "${dest}"
+runTest 0 $output snakedeploy deploy-workflow "${repo}" "${dest}"
 
 echo
 echo "#### Testing snakedeploy directory exists"
-runTest 1 $output snakedeploy "${repo}" "${dest}"
+runTest 1 $output snakedeploy deploy-workflow "${repo}" "${dest}"
 
 rm -rf ${tmpdir}


### PR DESCRIPTION
Here are some suggestions for updating #8. Specifically:

### Changes

- we remove the pandas dependency, replaced with a simple function to read csv. I didn't see in the example provided that there was a header with names (e.g., `input_patterns`) so instead I am using index (input patterns are in the first column) however I can update this if the file is intended to have a header (and allow the named row to be anywhere in the sheet).
- adding a version bump and entry to changelog
- adding docs to show the basics of how it would work.
- various tweaks to if/else statements
- updating docs and tests to use `deploy-workflow`
- running newer version of black (it's a moving target!)


### For discussion
- Should we have more organization around the addition of `collect_files.py` ? E.g., if it's an associated snakedeploy tool, I thought it might make sense to have a `tools` folder. If it's considered a file operation (and we intend to have more) we could make a `snakemake.files` operation. 
- Can we have an example samples.tsv so I can write a test?

Signed-off-by: vsoch <vsoch@users.noreply.github.com>