### PR TITLE
adding publish action for pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Build package
+      run: |
+        python -m pip install --upgrade pip
+        python setup.py sdist
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user:     __token__
+        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This will add a publish action for snakedeploy to pypi to close #10. We can merge this when it passes, then I'll draft the release to test it.