### PR TITLE
Exclude "tests" package from dist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
         author_email=AUTHOR_EMAIL,
         maintainer=AUTHOR,
         maintainer_email=AUTHOR_EMAIL,
-        packages=find_packages(),
+        packages=find_packages(exclude=["tests"]),
         include_package_data=True,
         zip_safe=False,
         url=PACKAGE_URL,


### PR DESCRIPTION
This removes the included "tests" package from the built distribution.
Including it will cause file collisions (/overwrites) for `site-packages/tests/__init__.py` on installation.
Excluding it, however, means that the sdist also does not carry this file anymore, i.e., the `setup_requires=["pytest-runner"]` will not pick it up anymore -- which isn't much of a regression since the `tests/*.sh` files aren't included in the sdist anyway. (I.e., `setup_requires=["pytest-runner"]` is a quasi no-op apart from when run from the repo itself (or archive of it), so, I'd suggest to remove it from `setup.py` and invoke `pytest` directly.)