### PR TITLE
fix: Removing quotes from around snakefile in use_module template

### DIFF
--- a/snakedeploy/templates/use_module.smk.jinja
+++ b/snakedeploy/templates/use_module.smk.jinja
@@ -10,7 +10,7 @@ configfile: "config/config.yaml"
 # declare {{ repo }} as a module
 module {{ name }}:
     snakefile: 
-        "{{ snakefile }}"
+        {{ snakefile }}
     config:
         config
 


### PR DESCRIPTION
Currently, GitHub is the only provider and having quotes is an error. Instead of hard coding them into the template, we should take an approach of having the provider determine to add/not add them.

This will fix #22 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>