### PR TITLE
fix: Fix snakedeploy hanging forever

### DIFF
--- a/snakedeploy/conda.py
+++ b/snakedeploy/conda.py
@@ -193,7 +193,7 @@ class CondaEnvProcessor:
                     self.exec_conda(f"list --json --prefix {tmpdir}").stdout
                 )
                 pkg_versions = {pkg["name"]: pkg["version"] for pkg in results}
-                self.exec_conda(f"env remove --prefix {tmpdir}")
+                self.exec_conda(f"env remove --prefix {tmpdir} -y")
             return pkg_versions, results
 
         logger.info("Resolving prior versions...")
@@ -292,7 +292,7 @@ class CondaEnvProcessor:
                         is_updated=old_content is not None,
                         msg=msg,
                     )
-            self.exec_conda(f"env remove --prefix {tmpdir}")
+            self.exec_conda(f"env remove --prefix {tmpdir} -y")
 
     def exec_conda(self, subcmd):
         return sp.run(


### PR DESCRIPTION
This PR fixes #63 by adding `-y` to the `env remove` calls. It seems like the conda frontend is waiting for user input and therefore taking forever.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the environment removal process by adding automatic confirmation, streamlining user experience.
  
- **Bug Fixes**
	- Resolved issues related to user prompts during environment removal, making it non-interactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->