### PR TITLE
fix: use conda instead of mamba by default

### DIFF
--- a/snakedeploy/client.py
+++ b/snakedeploy/client.py
@@ -129,9 +129,9 @@ def get_parser():
     )
     pin_conda_envs.add_argument(
         "--conda-frontend",
-        choices=["mamba", "conda"],
-        default="mamba",
-        help="Conda frontend to use (default: mamba).",
+        choices=["conda", "mamba"],
+        default="conda",
+        help="Conda frontend to use (default: conda).",
     )
     pin_conda_envs.add_argument(
         "--create-prs",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `--conda-frontend` argument options for `pin-conda-envs` and `update-conda-envs` commands to include `conda` as the default choice.
  
- **Bug Fixes**
	- Maintained consistent error handling for missing `--tag` or `--branch` during the `deploy-workflow` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->