### PR TITLE
feat: add profile directory and license file to deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 snakedeploy.egg-info/
 _build
+build
 .eggs/
 __pycache__
 dist

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ __license__ = "MPL 2.0"
 from setuptools import setup, find_packages
 import versioneer
 import os
-import urllib.request
 
 
 def get_lookup():

--- a/snakedeploy/deploy.py
+++ b/snakedeploy/deploy.py
@@ -92,9 +92,8 @@ class WorkflowDeployer:
             )
         else:
             logger.info("Writing template profiles")
-            shutil.copytree(profile_dir, self.profile, dirs_exist_ok=self.force)
+            shutil.copytree(profile_dir, self.profiles, dirs_exist_ok=self.force)
         return no_profile
-
     def deploy_license(self):
         """
         Deploy the license file if it exists

--- a/snakedeploy/deploy.py
+++ b/snakedeploy/deploy.py
@@ -94,6 +94,7 @@ class WorkflowDeployer:
             logger.info("Writing template profiles")
             shutil.copytree(profile_dir, self.profiles, dirs_exist_ok=self.force)
         return no_profile
+
     def deploy_license(self):
         """
         Deploy the license file if it exists

--- a/snakedeploy/deploy.py
+++ b/snakedeploy/deploy.py
@@ -43,7 +43,7 @@ class WorkflowDeployer:
     @property
     def config(self):
         return self.dest_path / "config"
-    
+
     @property
     def profile(self):
         return self.dest_path / "profile"
@@ -102,9 +102,16 @@ class WorkflowDeployer:
         returns a boolean "no_license" to indicate if there is no license (True)
         """
         # List possible license file names and extensions
-        license_variants = ["license*", "License*", "LICENSE*", "licence*", "Licence*", "LICENCE*"]
-        licenses = [] # licenses found
-    
+        license_variants = [
+            "license*",
+            "License*",
+            "LICENSE*",
+            "licence*",
+            "Licence*",
+            "LICENCE*",
+        ]
+        licenses = []  # licenses found
+
         # Iterate over the variants and check if a license file exists in the directory
         for variant in license_variants:
             # Use glob to match files with any extension
@@ -148,10 +155,10 @@ class WorkflowDeployer:
         no_config = self.deploy_config()
 
         # Copy profile directory if it exists, see issue #64
-        no_profile = self.deploy_profile()
+        self.deploy_profile()
 
         # Copy license if it exists
-        no_license = self.deploy_license()
+        self.deploy_license()
 
         # Inspect repository to find existing snakefile
         self.deploy_snakefile(self.repo_clone, name)
@@ -175,7 +182,7 @@ class WorkflowDeployer:
             raise UserError(
                 f"{self.config} already exists, aborting (use --force to overwrite)"
             )
-        
+
         if self.profile.exists() and not self.force:
             raise UserError(
                 f"{self.profile} already exists, aborting (use --force to overwrite)"

--- a/snakedeploy/deploy.py
+++ b/snakedeploy/deploy.py
@@ -45,8 +45,8 @@ class WorkflowDeployer:
         return self.dest_path / "config"
 
     @property
-    def profile(self):
-        return self.dest_path / "profile"
+    def profiles(self):
+        return self.dest_path / "profiles"
 
     def deploy_config(self):
         """
@@ -82,7 +82,7 @@ class WorkflowDeployer:
         returns a boolean "no_profile" to indicate if there is not a profile (True)
         """
         # Handle the profile/
-        profile_dir = Path(self.repo_clone) / "profile"
+        profile_dir = Path(self.repo_clone) / "profiles"
         no_profile = not profile_dir.exists()
         if no_profile:
             logger.warning(
@@ -183,9 +183,9 @@ class WorkflowDeployer:
                 f"{self.config} already exists, aborting (use --force to overwrite)"
             )
 
-        if self.profile.exists() and not self.force:
+        if self.profiles.exists() and not self.force:
             raise UserError(
-                f"{self.profile} already exists, aborting (use --force to overwrite)"
+                f"{self.profiles} already exists, aborting (use --force to overwrite)"
             )
 
     def deploy_snakefile(self, tmpdir: str, name: str):

--- a/snakedeploy/deploy.py
+++ b/snakedeploy/deploy.py
@@ -1,3 +1,4 @@
+import glob
 import tempfile
 from pathlib import Path
 import os
@@ -42,6 +43,10 @@ class WorkflowDeployer:
     @property
     def config(self):
         return self.dest_path / "config"
+    
+    @property
+    def profile(self):
+        return self.dest_path / "profile"
 
     def deploy_config(self):
         """
@@ -70,6 +75,56 @@ class WorkflowDeployer:
             shutil.copytree(config_dir, self.config, dirs_exist_ok=self.force)
         return no_config
 
+    def deploy_profile(self):
+        """
+        Deploy the profile directory if it exists
+
+        returns a boolean "no_profile" to indicate if there is not a profile (True)
+        """
+        # Handle the profile/
+        profile_dir = Path(self.repo_clone) / "profile"
+        no_profile = not profile_dir.exists()
+        if no_profile:
+            logger.warning(
+                "No profile directory found in source repository. "
+                "Please check whether the source repository really does not "
+                "need or provide any profiles."
+            )
+        else:
+            logger.info("Writing template profiles")
+            shutil.copytree(profile_dir, self.profile, dirs_exist_ok=self.force)
+        return no_profile
+
+    def deploy_license(self):
+        """
+        Deploy the license file if it exists
+
+        returns a boolean "no_license" to indicate if there is no license (True)
+        """
+        # List possible license file names and extensions
+        license_variants = ["license*", "License*", "LICENSE*", "licence*", "Licence*", "LICENCE*"]
+        licenses = [] # licenses found
+    
+        # Iterate over the variants and check if a license file exists in the directory
+        for variant in license_variants:
+            # Use glob to match files with any extension
+            matching_files = glob.glob(os.path.join(self.repo_clone, variant))
+            if matching_files:
+                licenses.extend(matching_files)
+
+        license_file = Path(licenses[0]) if len(licenses) != 0 else None
+        if license_file is None:
+            no_license = True
+        else:
+            no_license = not license_file.exists()
+
+        if no_license:
+            pass
+        else:
+            logger.info("Writing license")
+            shutil.copy(license_file, self.dest_path)
+        return no_license
+
     @property
     def repo_clone(self):
         if self._cloned is None:
@@ -92,6 +147,12 @@ class WorkflowDeployer:
         # Either copy existing config or create a dummy config
         no_config = self.deploy_config()
 
+        # Copy profile directory if it exists, see issue #64
+        no_profile = self.deploy_profile()
+
+        # Copy license if it exists
+        no_license = self.deploy_license()
+
         # Inspect repository to find existing snakefile
         self.deploy_snakefile(self.repo_clone, name)
 
@@ -113,6 +174,11 @@ class WorkflowDeployer:
         if self.config.exists() and not self.force:
             raise UserError(
                 f"{self.config} already exists, aborting (use --force to overwrite)"
+            )
+        
+        if self.profile.exists() and not self.force:
+            raise UserError(
+                f"{self.profile} already exists, aborting (use --force to overwrite)"
             )
 
     def deploy_snakefile(self, tmpdir: str, name: str):


### PR DESCRIPTION
This PR implements #64 and also deploys a license if it's present in the repository.
As licenses usually state that they shall be included in all copies of a software this is a nice feature to have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated repository configuration to ignore generated build artifacts.
	- Removed unnecessary import statement in setup configuration.
- **New Features**
	- Enhanced the deployment workflow with streamlined handling of profile data and license files.
	- Added methods for deploying profiles and licenses, improving deployment process integration. 
	- Introduced a property for accessing the profiles directory path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->