### PR TITLE
fix: get release-please to work again, by removing package-name entry

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,6 @@ jobs:
         id: release
         with:
           release-type: python
-          package-name: snakedeploy
 
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the release automation by adjusting a configuration parameter related to package identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->