### PR TITLE
ci: make release-please future-proof with token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ jobs:
         id: release
         with:
           release-type: python
+          token: ${{ secrets.RELEASE_PLEASE_PR_CI_TOKEN }}
 
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
In the case that status checks ever get added to `main` branch protections, this will ensure that GitHub Actions workflows can run and the checks can thus pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the automated release process by updating the configuration to include a secure token parameter for improved authentication. This adjustment strengthens the reliability and security of our release workflow without changing current functionality. It reflects our ongoing efforts to streamline operations and ensure a seamless, high-quality experience for our users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->