### PR TITLE
feat: glab hosts

### DIFF
--- a/snakedeploy/deploy.py
+++ b/snakedeploy/deploy.py
@@ -21,6 +21,7 @@ class WorkflowDeployer:
         tag: Optional[str] = None,
         branch: Optional[str] = None,
         force=False,
+        host: Optional[str] = None,
     ):
         self.provider = get_provider(source)
         self.env = Environment(loader=PackageLoader("snakedeploy"))
@@ -29,6 +30,7 @@ class WorkflowDeployer:
         self._cloned = None
         self.tag = tag
         self.branch = branch
+        self.host = host
 
     def __enter__(self):
         return self
@@ -227,7 +229,7 @@ class WorkflowDeployer:
         module_deployment = template.render(
             name=name,
             snakefile=self.provider.get_source_file_declaration(
-                snakefile, self.tag, self.branch
+                snakefile, self.tag, self.branch, self.host
             ),
             repo=self.provider.source_url,
             config=config,
@@ -253,6 +255,7 @@ def deploy(
     branch: Optional[str],
     dest_path: Path,
     force=False,
+    host: Optional[str] = None,
 ):
     """
     Deploy a given workflow to the local machine, using the Snakemake module system.

--- a/snakedeploy/providers.py
+++ b/snakedeploy/providers.py
@@ -1,9 +1,11 @@
-from abc import abstractmethod, ABC
-from shutil import copytree
-import shutil
-from snakedeploy.exceptions import UserError
-import subprocess as sp
 import os
+import shutil
+import subprocess as sp
+from abc import ABC, abstractmethod
+from shutil import copytree
+from typing import Optional
+
+from snakedeploy.exceptions import UserError
 
 
 def get_provider(source_url):
@@ -31,16 +33,20 @@ class Provider(ABC):
 
     @classmethod
     @abstractmethod
-    def matches(cls, source_url: str): ...
+    def matches(cls, source_url: str):
+        ...
 
     @abstractmethod
-    def clone(self, path: str): ...
+    def clone(self, path: str):
+        ...
 
     @abstractmethod
-    def checkout(self, path: str, ref: str): ...
+    def checkout(self, path: str, ref: str):
+        ...
 
     @abstractmethod
-    def get_raw_file(self, path: str, tag: str): ...
+    def get_raw_file(self, path: str, tag: str):
+        ...
 
     def get_repo_name(self):
         return self.source_url.split("/")[-1]
@@ -126,7 +132,8 @@ class Gitlab(Github):
     ):
         owner_repo = "/".join(self.source_url.split("/")[-2:])
         url_host = self.source_url.split("/")[2]
-        breakpoint()
+        if host is None and url_host != "gitlab.com":
+            host = url_host
         if not (tag or branch):
             raise UserError("Either tag or branch has to be specified for deployment.")
         ref_arg = f'tag="{tag}"' if tag is not None else f'branch="{branch}"'

--- a/snakedeploy/providers.py
+++ b/snakedeploy/providers.py
@@ -73,7 +73,9 @@ class Local(Provider):
             )
         return f"{self.source_url}/{path}"
 
-    def get_source_file_declaration(self, path: str, tag: str, branch: str):
+    def get_source_file_declaration(
+        self, path: str, tag: str, branch: str, host: Optional[str] = None
+    ):
         relative_path = path.replace(self.source_url, "").strip(os.sep)
         return f'"{relative_path}"'
 
@@ -105,7 +107,9 @@ class Github(Provider):
     def get_raw_file(self, path: str, tag: str):
         return f"{self.source_url}/raw/{tag}/{path}"
 
-    def get_source_file_declaration(self, path: str, tag: str, branch: str):
+    def get_source_file_declaration(
+        self, path: str, tag: str, branch: str, host: Optional[str] = None
+    ):
         owner_repo = "/".join(self.source_url.split("/")[-2:])
         if not (tag or branch):
             raise UserError("Either tag or branch has to be specified for deployment.")
@@ -116,6 +120,18 @@ class Github(Provider):
 class Gitlab(Github):
     def get_raw_file(self, path: str, tag: str):
         return f"{self.source_url}/-/raw/{tag}/{path}"
+
+    def get_source_file_declaration(
+        self, path: str, tag: str, branch: str, host: Optional[str] = None
+    ):
+        owner_repo = "/".join(self.source_url.split("/")[-2:])
+        url_host = self.source_url.split("/")[2]
+        breakpoint()
+        if not (tag or branch):
+            raise UserError("Either tag or branch has to be specified for deployment.")
+        ref_arg = f'tag="{tag}"' if tag is not None else f'branch="{branch}"'
+        host_arg = f'host="{host}"' if host is not None else ""
+        return f'{self.name}("{owner_repo}", path="{path}", {ref_arg}, {host_arg})'
 
 
 PROVIDERS = [Github, Gitlab, Local]


### PR DESCRIPTION
closes #96 

This automatically detects the gitlab host you used and injects it into the provided snakemake module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom host during deployment.
  * Improved compatibility with self-hosted GitHub and GitLab instances when generating source declarations.
  * Maintains backward compatibility: if no host is provided, behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->