### PR TITLE
fix: synchronize scheduler skeleton

### DIFF
--- a/snakedeploy/templates/plugins/scheduler-plugins/init.py
+++ b/snakedeploy/templates/plugins/scheduler-plugins/init.py
@@ -62,7 +62,7 @@ class Scheduler(SchedulerBase):
         remaining_jobs: Sequence[JobSchedulerInterface],
         available_resources: Mapping[str, Union[int, str]],
         input_sizes: Mapping[AnnotatedStringInterface, int],
-    ) -> Sequence[JobSchedulerInterface]:
+    ) -> Optional[Sequence[JobSchedulerInterface]]:
         # Select jobs from the selectable jobs sequence. Thereby, ensure that the selected
         # jobs do not exceed the available resources.
 
@@ -82,4 +82,8 @@ class Scheduler(SchedulerBase):
         # the footprint of temporary files. The function uses async I/O under the hood,
         # thus make sure to call it only once per job selection and collect all files of
         # interest for a that single call.
+
+        # Return None to indicate an error in the selection process that shall lead to
+        # a fallback to the Snakemake's internal greedy scheduler.
+        # Otherwise, return the sequence of selected jobs.
         ...


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of job scheduling by allowing the scheduler plugin to signal errors and automatically fall back to the built-in greedy scheduler, preventing pipeline stalls.
  * Ensures workflows continue running instead of aborting when job selection fails.
  * No user configuration changes required; normal operation is unaffected.
  * No expected performance impact under typical conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->