### PR TITLE
fix: always update pins on `update-conda-envs --pin-envs`

### DIFF
--- a/snakedeploy/conda.py
+++ b/snakedeploy/conda.py
@@ -147,11 +147,7 @@ class CondaEnvProcessor:
                     updated = self.update_env(
                         conda_env_path, pr=pr, warn_on_error=warn_on_error
                     )
-                if pin_envs and (
-                    not update_envs
-                    or updated
-                    or not self.get_pin_file_path(conda_env_path).exists()
-                ):
+                if pin_envs:
                     logger.info(f"Pinning {conda_env_path}...")
                     self.update_pinning(conda_env_path, pr)
             except sp.CalledProcessError as e:


### PR DESCRIPTION
During `update-conde-envs --pin-envs environment.yaml`, if the environment.yaml has no changes (e.g. if completely unconstrained), the pins would never be touched, even though there will likely be newer versions that fulfill the implicit `*` constraints. This change now always tries updating the pins _if_ `--pin-envs` is provided (which I'd say is the expected behaviour?)