### PR TITLE
feat: when deploying profiles also add non standard directory paths

### DIFF
--- a/snakedeploy/conda.py
+++ b/snakedeploy/conda.py
@@ -127,9 +127,9 @@ class CondaEnvProcessor:
                         "Cannot add label to PR without --entity-regex specified."
                     )
 
-                assert (
-                    pin_envs or update_envs
-                ), "bug: either pin_envs or update_envs must be True"
+                assert pin_envs or update_envs, (
+                    "bug: either pin_envs or update_envs must be True"
+                )
                 mode = "bump" if update_envs else "pin"
                 pr = PR(
                     f"perf: auto{mode} {entity}",

--- a/versioneer.py
+++ b/versioneer.py
@@ -417,9 +417,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
     return stdout, p.returncode
 
 
-LONG_VERSION_PY[
-    "git"
-] = r'''
+LONG_VERSION_PY["git"] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -1456,9 +1454,9 @@ def get_versions(verbose=False):
     handlers = HANDLERS.get(cfg.VCS)
     assert handlers, "unrecognized VCS '%s'" % cfg.VCS
     verbose = verbose or cfg.verbose
-    assert (
-        cfg.versionfile_source is not None
-    ), "please set versioneer.versionfile_source"
+    assert cfg.versionfile_source is not None, (
+        "please set versioneer.versionfile_source"
+    )
     assert cfg.tag_prefix is not None, "please set versioneer.tag_prefix"
 
     versionfile_abs = os.path.join(root, cfg.versionfile_source)


### PR DESCRIPTION
This PR merely adds another directory to deploy when deploying profiles. Yes, this is a non-standard approach, but snakedeploy will silently ignore this. I recommend doing so to avoid dissappointment from users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More flexible profile discovery: searches root-level profiles first, then falls back to workflow profiles if needed.
  - Clearer logging: shows the exact source path of the selected profiles and adds an informational note encouraging contributions of adapted profiles.

- Refactor
  - Reformatted assertions for readability without changing behavior.

- Style
  - Minor formatting updates to configuration mappings and assertions; no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->