### PR TITLE
fix: scheduler template

### DIFF
--- a/snakedeploy/scaffold_plugins/common.py
+++ b/snakedeploy/scaffold_plugins/common.py
@@ -82,7 +82,7 @@ class ScaffoldPlugin(ABC):
             "coverage",
             "pytest",
             "twine",
-            "python-build",
+            "build",
         ]
         if self.include_snakemake_dev_dependency():
             dev_deps.append("snakemake")

--- a/snakedeploy/templates/plugins/release_please.yml.j2
+++ b/snakedeploy/templates/plugins/release_please.yml.j2
@@ -19,6 +19,7 @@ jobs:
         with:
           release-type: python
           package-name: {{ pyproject["project"]["name"] }}
+          token: {{ "${{ secrets.RELEASE_PLEASE_PR_CI_TOKEN }}" }}
 
   publish:
     runs-on: ubuntu-latest
@@ -36,7 +37,7 @@ jobs:
 
       - name: Build source and wheel distribution + check build
         run: |
-          pixi run check-build
+          pixi run -e dev check-build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Some small fixes I noticed when deploying [snakemake-scheduler-plugin-firstfit](https://github.com/snakemake/snakemake-scheduler-plugin-firstfit):
- run build in `dev` env
- install `build` instead of `python-build`
- add token to `release-please`