### PR TITLE
docs: add info on `profiles/` deployment to workflow_deployment.rst

### DIFF
--- a/docs/workflow_users/workflow_deployment.rst
+++ b/docs/workflow_users/workflow_deployment.rst
@@ -35,7 +35,7 @@ For the example above, it will have the following content
     use rule * from dna_seq_varlociraptor
 
 utilizing `Snakemake's module system <https://snakemake.readthedocs.io/en/stable/snakefiles/deployment.html#using-and-combining-pre-exising-workflows>`__.
-In addition, it will copy over the ``config/`` and ``profiles/`` directories of the given repository (and their contents) into respective directories under``/tmp/dest/``.
+In addition, it will copy over the ``config/`` and ``profiles/`` directories of the given repository (and their contents) into respective directories under ``/tmp/dest/``.
 These should be seen as a template, and can be modified according to your needs.
 Further, the workflow definition Snakefile can be arbitrarily extended and modified, thereby making any changes to the used workflow transparent (also see the `snakemake module documentation <https://snakemake.readthedocs.io/en/stable/snakefiles/modularization.html#snakefiles-modules>`_).
 

--- a/docs/workflow_users/workflow_deployment.rst
+++ b/docs/workflow_users/workflow_deployment.rst
@@ -36,7 +36,7 @@ For the example above, it will have the following content
 
 utilizing `Snakemake's module system <https://snakemake.readthedocs.io/en/stable/snakefiles/deployment.html#using-and-combining-pre-exising-workflows>`__.
 In addition, it will copy over the ``config/`` and ``profiles/`` directories of the given repository (and their contents) into respective directories under ``/tmp/dest/``.
-These should be seen as a template, and can be modified according to your needs.
+These should be seen as templates, and can be modified according to your needs.
 Further, the workflow definition Snakefile can be arbitrarily extended and modified, thereby making any changes to the used workflow transparent (also see the `snakemake module documentation <https://snakemake.readthedocs.io/en/stable/snakefiles/modularization.html#snakefiles-modules>`_).
 
 It is highly advisable to put the deployed workflow into a new (perhaps private) git repository (e.g., see `here <https://docs.github.com/en/github/importing-your-projects-to-github/adding-an-existing-project-to-github-using-the-command-line>`_ for instructions how to do that with Github).

--- a/docs/workflow_users/workflow_deployment.rst
+++ b/docs/workflow_users/workflow_deployment.rst
@@ -35,8 +35,8 @@ For the example above, it will have the following content
     use rule * from dna_seq_varlociraptor
 
 utilizing `Snakemake's module system <https://snakemake.readthedocs.io/en/stable/snakefiles/deployment.html#using-and-combining-pre-exising-workflows>`__.
-In addition, it will copy over the contents of the ``config`` directory of the given repository into ``/tmp/dest/workflow/Snakefile``.
-These should be seen as a template, can be modified according to your needs.
+In addition, it will copy over the ``config/`` and ``profiles/`` directories of the given repository (and their contents) into respective directories under``/tmp/dest/``.
+These should be seen as a template, and can be modified according to your needs.
 Further, the workflow definition Snakefile can be arbitrarily extended and modified, thereby making any changes to the used workflow transparent (also see the `snakemake module documentation <https://snakemake.readthedocs.io/en/stable/snakefiles/modularization.html#snakefiles-modules>`_).
 
 It is highly advisable to put the deployed workflow into a new (perhaps private) git repository (e.g., see `here <https://docs.github.com/en/github/importing-your-projects-to-github/adding-an-existing-project-to-github-using-the-command-line>`_ for instructions how to do that with Github).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment docs: the deployment copy operation now includes both configuration and profiles, with contents placed into corresponding subdirectories at the deployment destination.
  * Minor wording tweaks for clarity (pluralization and template phrasing).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->