### PR TITLE
fix: only check for downgraded packages among the constrained dependencies, do not perform update in that case if warn on error is active

### DIFF
--- a/snakedeploy/conda.py
+++ b/snakedeploy/conda.py
@@ -164,7 +164,12 @@ class CondaEnvProcessor:
                         return dep
                 return func(m.group("name"))
 
-            return list(filter(process_dependency, conda_env["dependencies"]))
+            return list(
+                filter(
+                    lambda item: item is not None,
+                    map(process_dependency, conda_env["dependencies"]),
+                )
+            )
 
         def get_pkg_versions(conda_env_path):
             with tempfile.TemporaryDirectory(dir=".", prefix=".") as tmpdir:

--- a/snakedeploy/conda.py
+++ b/snakedeploy/conda.py
@@ -133,6 +133,7 @@ class CondaEnvProcessor:
                 msg = f"Failed for conda env {conda_env_path}:\n{e.stderr}\n{e.stdout}"
                 if warn_on_error:
                     logger.warning(msg)
+                    continue
                 else:
                     raise UserError(msg)
             if create_prs:

--- a/snakedeploy/conda.py
+++ b/snakedeploy/conda.py
@@ -202,7 +202,9 @@ class CondaEnvProcessor:
                 if prior_version is not None and version < VersionOrder(prior_version):
                     yield pkg_name
 
-        downgraded = set(process_dependencies(lambda name: name, only_constrained=True)) & set(downgraded())
+        downgraded = set(
+            process_dependencies(lambda name: name, only_constrained=True)
+        ) & set(downgraded())
         if downgraded:
             msg = (
                 f"Env {conda_env_path} could not be updated because the following packages "

--- a/snakedeploy/conda.py
+++ b/snakedeploy/conda.py
@@ -149,18 +149,21 @@ class CondaEnvProcessor:
         with open(conda_env_path, "r") as infile:
             conda_env = yaml.load(infile, Loader=yaml.SafeLoader)
 
-        def process_dependencies(func):
+        def process_dependencies(func, only_constrained=False):
             def process_dependency(dep):
                 if isinstance(dep, dict):
                     # leave e.g. pip subdicts unchanged
                     return dep
-                m = spec_re.match(dep)
+                m = spec_re.match(dep.strip())
                 if m is None:
-                    # cannot parse the spec, leave unchanged
-                    return dep
+                    if only_constrained:
+                        return None
+                    else:
+                        # cannot parse the spec, leave unchanged
+                        return dep
                 return func(m.group("name"))
 
-            return [process_dependency(dep) for dep in conda_env["dependencies"]]
+            return list(filter(process_dependency, conda_env["dependencies"]))
 
         def get_pkg_versions(conda_env_path):
             with tempfile.TemporaryDirectory(dir=".", prefix=".") as tmpdir:
@@ -199,7 +202,7 @@ class CondaEnvProcessor:
                 if prior_version is not None and version < VersionOrder(prior_version):
                     yield pkg_name
 
-        downgraded = set(unconstrained_deps) & set(downgraded())
+        downgraded = set(process_dependencies(lambda name: name, only_constrained=True)) & set(downgraded())
         if downgraded:
             msg = (
                 f"Env {conda_env_path} could not be updated because the following packages "
@@ -208,6 +211,7 @@ class CondaEnvProcessor:
             )
             if warn_on_error:
                 logger.warning(msg)
+                return False
             else:
                 raise UserError(msg)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency parsing for conda environments to enforce stricter constraint validation and discard unparseable entries.
  * Faster failure behavior when package downgrades or conda execution errors occur: updates stop immediately with a warning instead of proceeding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snakemake/snakedeploy/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->