### PR TITLE
feat: add --commit flag to deploy-workflow

### DIFF
--- a/docs/workflow_users/workflow_deployment.rst
+++ b/docs/workflow_users/workflow_deployment.rst
@@ -41,6 +41,24 @@ Further, the workflow definition Snakefile can be arbitrarily extended and modif
 
 It is highly advisable to put the deployed workflow into a new (perhaps private) git repository (e.g., see `here <https://docs.github.com/en/github/importing-your-projects-to-github/adding-an-existing-project-to-github-using-the-command-line>`_ for instructions how to do that with Github).
 
+If you want to pin the deployment to an exact commit (e.g. for full reproducibility independent of any future changes to a branch or tag), use ``--commit`` instead of ``--tag``/``--branch``:
+
+.. code-block:: console
+
+    $ snakedeploy deploy-workflow https://github.com/snakemake-workflows/dna-seq-varlociraptor /tmp/dest --commit 87709354b54391aee5dbb01a64cacfc20aed5ec3
+
+This will generate a module declaration pinned to that exact commit:
+
+.. code-block:: python
+
+    module dna_seq_varlociraptor:
+        snakefile:
+            github("snakemake-workflows/dna-seq-varlociraptor", path="workflow/Snakefile", commit="87709354b54391aee5dbb01a64cacfc20aed5ec3")
+        config:
+            config
+
+Note that ``--commit``, ``--tag``, and ``--branch`` are mutually exclusive: exactly one of them has to be specified.
+
 For more options and details, run
 
 .. code-block:: console

--- a/docs/workflow_users/workflow_deployment.rst
+++ b/docs/workflow_users/workflow_deployment.rst
@@ -41,6 +41,25 @@ Further, the workflow definition Snakefile can be arbitrarily extended and modif
 
 It is highly advisable to put the deployed workflow into a new (perhaps private) git repository (e.g., see `here <https://docs.github.com/en/github/importing-your-projects-to-github/adding-an-existing-project-to-github-using-the-command-line>`_ for instructions how to do that with Github).
 
+If you want to pin the deployment to an exact commit (e.g. for full reproducibility independent of any future changes to a branch or tag), use ``--commit`` instead of (or in addition to) ``--tag``/``--branch``:
+
+.. code-block:: console
+
+    $ snakedeploy deploy-workflow https://github.com/snakemake-workflows/dna-seq-varlociraptor /tmp/dest --branch main --commit 87709354b54391aee5dbb01a64cacfc20aed5ec3
+
+This will generate a module declaration pinned to that exact commit:
+
+.. code-block:: python
+
+    module dna_seq_varlociraptor:
+        snakefile:
+            github("snakemake-workflows/dna-seq-varlociraptor", path="workflow/Snakefile", commit="87709354b54391aee5dbb01a64cacfc20aed5ec3")
+        config:
+            config
+
+When ``--commit`` is combined with ``--branch`` or ``--tag``, the commit takes precedence both for checking out the repository locally during deployment and for the ref written into the generated ``Snakefile``.
+``--commit`` can also be used on its own, without ``--branch`` or ``--tag``.
+
 For more options and details, run
 
 .. code-block:: console

--- a/snakedeploy/client.py
+++ b/snakedeploy/client.py
@@ -89,6 +89,14 @@ def get_parser():
         help="Git branch to deploy from.",
     )
 
+    deploy_workflow_parser.add_argument(
+        "--commit",
+        help="Git commit (SHA) to deploy from and pin the resulting module to. "
+        "Can be combined with --branch or --tag to determine which ref to "
+        "clone/checkout locally, while pinning the generated Snakefile module "
+        "declaration to this exact commit.",
+    )
+
     deploy_group.add_argument(
         "--name",
         help="The name for the module in the resulting Snakefile (default: repository name).",
@@ -291,13 +299,14 @@ def main():
 
     try:
         if args.subcommand == "deploy-workflow":
-            if not (args.tag or args.branch):
-                raise UserError("Please specify either --tag or --branch")
+            if not (args.tag or args.branch or args.commit):
+                raise UserError("Please specify either --tag, --branch, or --commit")
             deploy(
                 args.repo,
                 name=args.name,
                 tag=args.tag,
                 branch=args.branch,
+                commit=args.commit,
                 dest_path=Path(args.dest),
                 force=args.force,
             )

--- a/snakedeploy/client.py
+++ b/snakedeploy/client.py
@@ -79,14 +79,21 @@ def get_parser():
         help="Path to create the deploying workflow in.",
     )
 
-    deploy_workflow_parser.add_argument(
+    ref_group = deploy_workflow_parser.add_mutually_exclusive_group(required=True)
+
+    ref_group.add_argument(
         "--tag",
         help="Git tag to deploy from (e.g. a certain release).",
     )
 
-    deploy_workflow_parser.add_argument(
+    ref_group.add_argument(
         "--branch",
         help="Git branch to deploy from.",
+    )
+
+    ref_group.add_argument(
+        "--commit",
+        help="Git commit (SHA) to deploy from and pin the resulting module to.",
     )
 
     deploy_group.add_argument(
@@ -291,13 +298,12 @@ def main():
 
     try:
         if args.subcommand == "deploy-workflow":
-            if not (args.tag or args.branch):
-                raise UserError("Please specify either --tag or --branch")
             deploy(
                 args.repo,
                 name=args.name,
                 tag=args.tag,
                 branch=args.branch,
+                commit=args.commit,
                 dest_path=Path(args.dest),
                 force=args.force,
             )

--- a/snakedeploy/deploy.py
+++ b/snakedeploy/deploy.py
@@ -20,6 +20,7 @@ class WorkflowDeployer:
         dest: Path,
         tag: Optional[str] = None,
         branch: Optional[str] = None,
+        commit: Optional[str] = None,
         force=False,
     ):
         self.provider = get_provider(source)
@@ -29,6 +30,7 @@ class WorkflowDeployer:
         self._cloned = None
         self.tag = tag
         self.branch = branch
+        self.commit = commit
 
     def __enter__(self):
         return self
@@ -138,7 +140,11 @@ class WorkflowDeployer:
             logger.info("Obtaining source repository...")
             self._cloned = tempfile.TemporaryDirectory()
             self.provider.clone(self._cloned.name)
-            if self.tag is not None:
+            # Check out the most specific ref available: a commit pins to an
+            # exact snapshot, so prefer it over tag/branch if given.
+            if self.commit is not None:
+                self.provider.checkout(self._cloned.name, self.commit)
+            elif self.tag is not None:
                 self.provider.checkout(self._cloned.name, self.tag)
             elif self.branch is not None:
                 self.provider.checkout(self._cloned.name, self.branch)
@@ -227,7 +233,7 @@ class WorkflowDeployer:
         module_deployment = template.render(
             name=name,
             snakefile=self.provider.get_source_file_declaration(
-                snakefile, self.tag, self.branch
+                snakefile, self.tag, self.branch, self.commit
             ),
             repo=self.provider.source_url,
             config=config,
@@ -252,6 +258,7 @@ def deploy(
     tag: Optional[str],
     branch: Optional[str],
     dest_path: Path,
+    commit: Optional[str] = None,
     force=False,
 ):
     """
@@ -273,8 +280,28 @@ def deploy(
            force=True
        )
 
+    A specific commit can also be pinned, optionally alongside a tag or
+    branch used to determine what to check out locally during deployment:
+
+    .. code-block:: python
+
+       from snakedeploy.deploy import deploy
+       deploy(
+           "https://github.com/snakemake-workflows/dna-seq-varlociraptor",
+           dest_path="/tmp/dest",
+           name="dna_seq",
+           branch="main",
+           commit="a1b2c3d4e5f6...",
+           force=True
+       )
+
     """
     with WorkflowDeployer(
-        source=source_url, dest=dest_path, tag=tag, branch=branch, force=force
+        source=source_url,
+        dest=dest_path,
+        tag=tag,
+        branch=branch,
+        commit=commit,
+        force=force,
     ) as sd:
         sd.deploy(name=name)

--- a/snakedeploy/deploy.py
+++ b/snakedeploy/deploy.py
@@ -20,6 +20,7 @@ class WorkflowDeployer:
         dest: Path,
         tag: Optional[str] = None,
         branch: Optional[str] = None,
+        commit: Optional[str] = None,
         force=False,
     ):
         self.provider = get_provider(source)
@@ -29,6 +30,7 @@ class WorkflowDeployer:
         self._cloned = None
         self.tag = tag
         self.branch = branch
+        self.commit = commit
 
     def __enter__(self):
         return self
@@ -138,7 +140,9 @@ class WorkflowDeployer:
             logger.info("Obtaining source repository...")
             self._cloned = tempfile.TemporaryDirectory()
             self.provider.clone(self._cloned.name)
-            if self.tag is not None:
+            if self.commit is not None:
+                self.provider.checkout(self._cloned.name, self.commit)
+            elif self.tag is not None:
                 self.provider.checkout(self._cloned.name, self.tag)
             elif self.branch is not None:
                 self.provider.checkout(self._cloned.name, self.branch)
@@ -227,7 +231,7 @@ class WorkflowDeployer:
         module_deployment = template.render(
             name=name,
             snakefile=self.provider.get_source_file_declaration(
-                snakefile, self.tag, self.branch
+                snakefile, self.tag, self.branch, self.commit
             ),
             repo=self.provider.source_url,
             config=config,
@@ -252,6 +256,7 @@ def deploy(
     tag: Optional[str],
     branch: Optional[str],
     dest_path: Path,
+    commit: Optional[str] = None,
     force=False,
 ):
     """
@@ -273,8 +278,27 @@ def deploy(
            force=True
        )
 
+    Instead of a tag or branch, a specific commit can be pinned (the three
+    are mutually exclusive):
+
+    .. code-block:: python
+
+       from snakedeploy.deploy import deploy
+       deploy(
+           "https://github.com/snakemake-workflows/dna-seq-varlociraptor",
+           dest_path="/tmp/dest",
+           name="dna_seq",
+           commit="a1b2c3d4e5f6...",
+           force=True
+       )
+
     """
     with WorkflowDeployer(
-        source=source_url, dest=dest_path, tag=tag, branch=branch, force=force
+        source=source_url,
+        dest=dest_path,
+        tag=tag,
+        branch=branch,
+        commit=commit,
+        force=force,
     ) as sd:
         sd.deploy(name=name)

--- a/snakedeploy/providers.py
+++ b/snakedeploy/providers.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod, ABC
 from shutil import copytree
 import shutil
+from typing import Optional
 from snakedeploy.exceptions import UserError
 import subprocess as sp
 import os
@@ -73,7 +74,9 @@ class Local(Provider):
             )
         return f"{self.source_url}/{path}"
 
-    def get_source_file_declaration(self, path: str, tag: str, branch: str):
+    def get_source_file_declaration(
+        self, path: str, tag: str, branch: str, commit: Optional[str] = None
+    ):
         relative_path = path.replace(self.source_url, "").strip(os.sep)
         return f'"{relative_path}"'
 
@@ -105,11 +108,20 @@ class Github(Provider):
     def get_raw_file(self, path: str, tag: str):
         return f"{self.source_url}/raw/{tag}/{path}"
 
-    def get_source_file_declaration(self, path: str, tag: str, branch: str):
+    def get_source_file_declaration(
+        self, path: str, tag: str, branch: str, commit: Optional[str] = None
+    ):
         owner_repo = "/".join(self.source_url.split("/")[-2:])
-        if not (tag or branch):
-            raise UserError("Either tag or branch has to be specified for deployment.")
-        ref_arg = f'tag="{tag}"' if tag is not None else f'branch="{branch}"'
+        if not (tag or branch or commit):
+            raise UserError(
+                "Either tag, branch, or commit has to be specified for deployment."
+            )
+        if commit is not None:
+            ref_arg = f'commit="{commit}"'
+        elif tag is not None:
+            ref_arg = f'tag="{tag}"'
+        else:
+            ref_arg = f'branch="{branch}"'
         return f'{self.name}("{owner_repo}", path="{path}", {ref_arg})'
 
 

--- a/snakedeploy/providers.py
+++ b/snakedeploy/providers.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod, ABC
 from shutil import copytree
 import shutil
+from typing import Optional
 from snakedeploy.exceptions import UserError
 import subprocess as sp
 import os
@@ -73,7 +74,9 @@ class Local(Provider):
             )
         return f"{self.source_url}/{path}"
 
-    def get_source_file_declaration(self, path: str, tag: str, branch: str):
+    def get_source_file_declaration(
+        self, path: str, tag: str, branch: str, commit: Optional[str] = None
+    ):
         relative_path = path.replace(self.source_url, "").strip(os.sep)
         return f'"{relative_path}"'
 
@@ -105,11 +108,22 @@ class Github(Provider):
     def get_raw_file(self, path: str, tag: str):
         return f"{self.source_url}/raw/{tag}/{path}"
 
-    def get_source_file_declaration(self, path: str, tag: str, branch: str):
+    def get_source_file_declaration(
+        self, path: str, tag: str, branch: str, commit: Optional[str] = None
+    ):
         owner_repo = "/".join(self.source_url.split("/")[-2:])
-        if not (tag or branch):
-            raise UserError("Either tag or branch has to be specified for deployment.")
-        ref_arg = f'tag="{tag}"' if tag is not None else f'branch="{branch}"'
+        if not (tag or branch or commit):
+            raise UserError(
+                "Either tag, branch, or commit has to be specified for deployment."
+            )
+        # A commit pins to an exact snapshot, so prefer it over tag/branch
+        # if more than one ref was given.
+        if commit is not None:
+            ref_arg = f'commit="{commit}"'
+        elif tag is not None:
+            ref_arg = f'tag="{tag}"'
+        else:
+            ref_arg = f'branch="{branch}"'
         return f'{self.name}("{owner_repo}", path="{path}", {ref_arg})'
 
 

--- a/tests/test_client.sh
+++ b/tests/test_client.sh
@@ -47,6 +47,14 @@ repo="https://gitlab.com/nate-d-olson/snaketestworkflow"
 runTest 0 $output snakedeploy deploy-workflow "${repo}" "${dest}" --name snake-test --branch master
 
 echo
+echo "#### Testing snakedeploy deployment pinned to a specific commit"
+dest=$tmpdir/commit-testing
+repo="https://github.com/snakemake-workflows/dna-seq-varlociraptor"
+commit_sha="87709354b54391aee5dbb01a64cacfc20aed5ec3"
+runTest 0 $output snakedeploy deploy-workflow "${repo}" "${dest}" --branch master --commit ${commit_sha} --name dna-seq-commit
+runTest 0 $output grep "commit=\"${commit_sha}\"" ${dest}/workflow/Snakefile
+
+echo
 echo "#### Testing snakedeploy local deployment"
 local=$tmpdir/rna-seq-star-deseq2
 repo="https://github.com/snakemake-workflows/rna-seq-star-deseq2"

--- a/tests/test_client.sh
+++ b/tests/test_client.sh
@@ -47,6 +47,15 @@ repo="https://gitlab.com/nate-d-olson/snaketestworkflow"
 runTest 0 $output snakedeploy deploy-workflow "${repo}" "${dest}" --name snake-test --branch master
 
 echo
+echo "#### Testing snakedeploy deployment pinned to a specific commit"
+dest=$tmpdir/commit-testing
+repo="https://github.com/snakemake-workflows/dna-seq-varlociraptor"
+commit_sha="87709354b54391aee5dbb01a64cacfc20aed5ec3"
+runTest 0 $output snakedeploy deploy-workflow "${repo}" "${dest}" --commit ${commit_sha} --name dna-seq-commit
+runTest 0 $output grep "commit=\"${commit_sha}\"" ${dest}/workflow/Snakefile
+runTest 2 $output snakedeploy deploy-workflow "${repo}" "${dest}" --branch master --commit ${commit_sha}
+
+echo
 echo "#### Testing snakedeploy local deployment"
 local=$tmpdir/rna-seq-star-deseq2
 repo="https://github.com/snakemake-workflows/rna-seq-star-deseq2"


### PR DESCRIPTION
snakedeploy deploy-workflow previously only allowed pinning a workflow deployment to a --tag or --branch, even though the underlying Snakemake github() helper also supports pinning to an exact commit via commit=. This meant users wanting full reproducibility (pinning to a specific commit rather than a potentially moving branch, or a repo with no tags) had to manually edit the generated Snakefile after deployment.

This adds a --commit option to the deploy-workflow subcommand:

- --commit can be used standalone, or combined with --branch/--tag.
- When given, it takes precedence for both the local checkout performed during deployment and the ref written into the generated module's github(...) call (commit="<sha>" instead of tag=/branch=).
- The local/Gitlab providers were updated accordingly, and a new test case was added to tests/test_client.sh.
- Docs in workflow_deployment.rst updated to document the new flag.

**LLM usage disclosure:** LLM tools were used to assist in generating parts of the code and PR description. The resulting changes were manually reviewed, edited, and tested by the author before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for deploying workflows from an exact Git commit using `--commit`.
  - Generated workflow declarations now record the pinned commit for reproducible deployments.
  - Deployment references are mutually exclusive: exactly one of `--commit`, `--tag`, or `--branch` must be provided.

- **Documentation**
  - Updated deployment guidance and examples to show commit-pinned deployments and clarify reference selection requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->